### PR TITLE
Change order of arguments for openssl rand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ sk sk.pub attestation.bin: challengefile
 
 # some random challenge data to hash
 challengefile:
-	openssl rand 128 -out challengefile
+	openssl rand -out challengefile 128
 
 ###
 ### parse attestation


### PR DESCRIPTION
Maybe a change in openssl 3?